### PR TITLE
defined target_type as "ip" in target groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ Terraform module to create Application Load Balancer, Target Group(s) and Listen
 ## Usage
 ```hcl
 module "simple_alb" {
-  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.0.0"
+  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.0.1"
   name = "example"
   port_mappings = [
     {
       public_port = 80
       target_port = 8000
-      health_check_path = null
-      health_check_port = null
     },
     {
       public_port = 443

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -8,7 +8,7 @@ module "acs" {
 }
 
 module "simple_alb" {
-  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.0.0"
+  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.0.1"
   //  source = "../"
   name = "example"
   port_mappings = [

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,7 @@ resource "aws_alb_target_group" "groups" {
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
   deregistration_delay = var.deregistration_delay
+  target_type          = "ip"
   health_check {
     path = local.health_checks[each.value].path
     interval            = local.health_checks[each.value].interval

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,8 @@ resource "aws_alb_target_group" "groups" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_alb.alb]
 }
 
 resource "aws_alb_listener" "listeners" {
@@ -101,4 +103,6 @@ resource "aws_alb_listener" "listeners" {
     type             = "forward"
     target_group_arn = aws_alb_target_group.groups[each.value].arn
   }
+
+  depends_on = [aws_alb.alb, aws_alb_target_group.groups]
 }


### PR DESCRIPTION
Found a bug where target group type needs to be "ip" instead of "instance"