### PR TITLE
Changed alb's target groups and listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module to create Application Load Balancer, Target Group(s) and Listen
 ## Usage
 ```hcl
 module "simple_alb" {
-  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
+  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.2.0"
   name       = "example"
   vpc_id     = module.acs.vpc.id
   subnet_ids = module.acs.public_subnet_ids

--- a/README.md
+++ b/README.md
@@ -7,36 +7,47 @@ Terraform module to create Application Load Balancer, Target Group(s) and Listen
 ```hcl
 module "simple_alb" {
   source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
-  name = "example"
-  vpc_id = module.acs.vpc.id
+  name       = "example"
+  vpc_id     = module.acs.vpc.id
   subnet_ids = module.acs.public_subnet_ids
-  default_target_group_config = {
-    type = "ip"
-        deregistration_delay = null
-        slow_start = null
-        health_check = {
-          path                = "/"
-          interval            = null
-          timeout             = null
-          healthy_threshold   = null
-          unhealthy_threshold = null
-        }
-        stickiness_cookie_duration = null
-  }
-  target_groups = [
-    {
-      name_suffix    = "blue"
-      listener_ports = [80]
-      port           = 8000
-      config         = null
-    },
-    {
-      name_suffix    = "green"
-      listener_ports = []
-      port           = 8000
-      config         = null
+  target_groups = {
+    main = {
+      port                 = 8000
+      type                 = "ip"
+      deregistration_delay = null
+      slow_start           = null
+      health_check = {
+        path                = "/"
+        interval            = null
+        timeout             = null
+        healthy_threshold   = null
+        unhealthy_threshold = null
+      }
+      stickiness_cookie_duration = null
     }
-  ]
+  }
+  listeners = {
+    80 = {
+      protocol              = "HTTP"
+      https_certificate_arn = null
+      redirect_to = {
+        host     = null
+        path     = null
+        port     = 443
+        protocol = "HTTPS"
+      }
+      forward_to = null
+    },
+    443 = {
+      protocol              = "HTTPS"
+      https_certificate_arn = module.acs.certificate.arn
+      redirect_to           = null
+      forward_to = {
+        target_group   = "main"
+        ignore_changes = false
+      }
+    }
+  }
 }
 ```
 
@@ -50,17 +61,35 @@ module "simple_alb" {
 | name | Application Load Balancer name | |
 | vpc_id | ID of the VPC | |
 | subnet_ids | List of subnet IDs for the targets of the ALB | |
-| default_target_group_config | Default configuration for `target_groups`. See [below](#default_target_group_config) | |
-| target_groups | List of information defining the target groups to create. See [below](#target_groups) | |
-| is_blue_green | Boolean to identify that this ALB will be used for blue green deployments. `true` will cause the listeners to ignore changes to the forwarded target group because code deploy can change that | false | 
+| target_groups | Map of information defining the target groups to create. See [below](#target_groups) | |
+| listeners | Map of information defining the listeners to create. See [below](#listeners) | |
 | idle_timeout | The time in seconds that the connection is allowed to be idle | 60 |
 | tags | Tags to attach to the ALB and target groups | {} |
 
 **Note:** In order to use built in defaults you need to set the attribute to `null` (since terraform doesn't support optional attributes in objects yet). Example in the [usage section](#usage) above.
 
-#### default_target_group_config
-In order to not have to define target group configuration for every target group you define, you can define some 
-defaults with this object. You can override the defaults on specific target groups if needed.
+#### target_groups
+A map of objects that define the target groups to create. The map's key is the name (actually the name suffix that will 
+be constructed with the name of the alb) of the target group you want to create.
+
+The target group's name will be `<alb.name>-tg-<map_key>`. This will also be how the outputs are mapped.
+
+For instance, the following will create two target groups named `example-tg-blue` and `example-tg-green`: 
+```hcl
+name       = "example"
+vpc_id     = module.acs.vpc.id
+subnet_ids = module.acs.public_subnet_ids
+target_groups = {
+  "blue" = {
+  //...
+  },
+  "green" = {
+  //...  
+  } 
+}
+```
+
+* `port` - (Required) The port of the target group.
 * `type` - (Optional) The type of target that you must specify when registering targets with this target group [`instance`, `ip`, or `lambda`]. Defaults to `instance`.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. Defaults to 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. Defaults to 0 seconds.
@@ -72,12 +101,21 @@ defaults with this object. You can override the defaults on specific target grou
     * `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3.
     * `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy. Defaults to 3.
 
-#### target_groups
-A list of objects that define the target groups to create along with the listener ports that forward traffic to each target group.
-* `name_suffix` - (Required) The suffix to append to the end of the target group name. The target group name will be `<alb.name>-tg-<target_group.name_suffix>`. This will also be how the outputs are mapped.
-* `listener_ports` - (Required) A list of public port numbers that you want to be forwarded to this target group. This will create ingress rules to the ALB's security group to allow traffic from anywhere to these specified ports.  
-* `port` - (Required) The port on which targets receive traffic.
-* `config` - (Optional) If provided, override all values in the [`default_target_group_config`](#default_target_group_config). (Same attributes as the  [`default_target_group_config`](#default_target_group_config) object).
+#### listeners
+A map of objects defining the listeners to create. The map's key is the listener or public port to create.
+
+A listener can be configured to either forward traffic to a target group or to redirect traffic. Defining both will probably result in an error.
+
+* `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are TCP, TLS, UDP, TCP_UDP, HTTP and HTTPS. Defaults to HTTP.
+* `https_certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS.
+* `forward_to` - (Optional) If this listener should forward traffic, define this object:
+    * `target_group` - (Required) The target group name suffix (or mapped key in the `target_groups` variables) to forward traffic to.
+    * `ignore_changes` - (Required) Boolean to tell terraform to ignore changes to this target group definition. This is useful when something else (like CodeDeploy) changes the listener's forwarded target group.
+* `redirect_to` - (Optional) If this listener should redirect traffic, define this object:
+    * `host` - (Optional) The hostname to direct traffic. This component is not percent-encoded. The hostname can contain #{host}. Defaults to #{host}.
+    * `path` - (Optional) The absolute path, starting with the leading "/". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. Defaults to /#{path}.
+    * `port` - (Optional) The port. Specify a value from 1 to 65535 or #{port}. Defaults to #{port}.
+    * `protocol` - (Optional) The protocol. Valid values are HTTP, HTTPS, or #{protocol}. Defaults to #{protocol}.
 
 ## Outputs
 | Name | Description |
@@ -107,7 +145,7 @@ target_groups = {
 }
 
 listeners = {
-  "80" = {
+  "443" = {
     "arn" = "..."
     "default_action" = {
       "target_group_arn" = "arn...example-tg-blue..."

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Latest GitHub Release](https://img.shields.io/github/v/release/byu-oit/terraform-aws-alb?sort=semver)
+
 # AWS Terraform ALB
 Terraform module to create Application Load Balancer, Target Group(s) and Listener(s)
 
@@ -37,6 +39,9 @@ module "simple_alb" {
   ]
 }
 ```
+
+## Requirements
+* Terraform version 0.12.16 or greater
 
 ## Inputs
 

--- a/examples/blue-green/blue-green-example.tf
+++ b/examples/blue-green/blue-green-example.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "us-west-2"
+  version = "~> 2.42"
+  region  = "us-west-2"
 }
 
 module "acs" {

--- a/examples/blue-green/blue-green-example.tf
+++ b/examples/blue-green/blue-green-example.tf
@@ -9,7 +9,7 @@ module "acs" {
 }
 
 module "blue_green_alb" {
-  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
+  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.2.0"
   //  source        = "../../"
   name       = "blue-green-example"
   vpc_id     = module.acs.vpc.id

--- a/examples/blue-green/blue-green-example.tf
+++ b/examples/blue-green/blue-green-example.tf
@@ -9,17 +9,18 @@ module "acs" {
 }
 
 module "blue_green_alb" {
-  source        = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
-  name          = "blue-green-example"
-  vpc_id        = module.acs.vpc.id
-  subnet_ids    = module.acs.public_subnet_ids
-  is_blue_green = true
+  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
+  //  source        = "../../"
+  name       = "blue-green-example"
+  vpc_id     = module.acs.vpc.id
+  subnet_ids = module.acs.public_subnet_ids
   target_groups = {
     blue = {
-      port                 = 8000
-      type                 = "ip" // or instance or lambda
-      deregistration_delay = null
-      slow_start           = null
+      port                       = 8000
+      type                       = "ip" // or instance or lambda
+      deregistration_delay       = null
+      slow_start                 = null
+      stickiness_cookie_duration = null
       health_check = {
         path                = "/"
         interval            = null
@@ -27,13 +28,13 @@ module "blue_green_alb" {
         healthy_threshold   = null
         unhealthy_threshold = null
       }
-      stickiness_cookie_duration = null
     },
     green = {
-      port                 = 8000
-      type                 = "ip" // or instance or lambda
-      deregistration_delay = null
-      slow_start           = null
+      port                       = 8000
+      type                       = "ip" // or instance or lambda
+      deregistration_delay       = null
+      slow_start                 = null
+      stickiness_cookie_duration = null
       health_check = {
         path                = "/"
         interval            = null
@@ -41,17 +42,28 @@ module "blue_green_alb" {
         healthy_threshold   = null
         unhealthy_threshold = null
       }
-      stickiness_cookie_duration = null
     }
   }
   listeners = {
     80 = {
-      redirect_to = 443
-      forward_to  = null
+      protocol              = "HTTP"
+      https_certificate_arn = null
+      redirect_to = {
+        host     = null
+        path     = null
+        port     = 443
+        protocol = "HTTPS"
+      }
+      forward_to = null
     },
     443 = {
-      redirect_to = null
-      forward_to  = "blue"
+      protocol              = "HTTPS"
+      https_certificate_arn = module.acs.certificate.arn
+      redirect_to           = null
+      forward_to = {
+        target_group   = "blue"
+        ignore_changes = false
+      }
     }
   }
 }

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "us-west-2"
+  version = "~> 2.42"
+  region  = "us-west-2"
 }
 
 module "acs" {

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -9,14 +9,15 @@ module "acs" {
 }
 
 module "simple_alb" {
-  source     = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
+  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
+  //  source     = "../../"
   name       = "simple-example"
   vpc_id     = module.acs.vpc.id
   subnet_ids = module.acs.public_subnet_ids
   target_groups = {
     main = {
       port                 = 8000
-      type                 = "ip" // or instance or lambda
+      type                 = "ip"
       deregistration_delay = null
       slow_start           = null
       health_check = {
@@ -31,12 +32,24 @@ module "simple_alb" {
   }
   listeners = {
     80 = {
-      redirect_to = 443
-      forward_to  = null
+      protocol              = "HTTP"
+      https_certificate_arn = null
+      redirect_to = {
+        host     = null
+        path     = null
+        port     = 443
+        protocol = "HTTPS"
+      }
+      forward_to = null
     },
     443 = {
-      redirect_to = null
-      forward_to  = "main"
+      protocol              = "HTTPS"
+      https_certificate_arn = module.acs.certificate.arn
+      redirect_to           = null
+      forward_to = {
+        target_group   = "main"
+        ignore_changes = false
+      }
     }
   }
 }

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -9,7 +9,7 @@ module "acs" {
 }
 
 module "simple_alb" {
-  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
+  source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.2.0"
   //  source     = "../../"
   name       = "simple-example"
   vpc_id     = module.acs.vpc.id

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -9,34 +9,34 @@ module "acs" {
 }
 
 module "simple_alb" {
-    source = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
-//  source = "../../" // used for local testing
-  name   = "simple-example"
+  source     = "git@github.com:byu-oit/terraform-aws-alb.git?ref=v1.1.0"
+  name       = "simple-example"
   vpc_id     = module.acs.vpc.id
   subnet_ids = module.acs.public_subnet_ids
-
-  default_target_group_config = {
-    type                 = "ip" // or instance or lambda
-    deregistration_delay = null
-    slow_start           = null
-    health_check = {
-      path                = "/"
-      interval            = null
-      timeout             = null
-      healthy_threshold   = null
-      unhealthy_threshold = null
+  target_groups = {
+    main = {
+      port                 = 8000
+      type                 = "ip" // or instance or lambda
+      deregistration_delay = null
+      slow_start           = null
+      health_check = {
+        path                = "/"
+        interval            = null
+        timeout             = null
+        healthy_threshold   = null
+        unhealthy_threshold = null
+      }
+      stickiness_cookie_duration = null
     }
-    stickiness_cookie_duration = null
   }
-  target_groups = [
-    {
-      listener_ports = [
-        80,
-        443
-      ]
-      name_suffix = "main"
-      port        = 8000
-      config      = null // use default
+  listeners = {
+    80 = {
+      redirect_to = 443
+      forward_to  = null
+    },
+    443 = {
+      redirect_to = null
+      forward_to  = "main"
     }
-  ]
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -5,43 +5,20 @@ terraform {
   }
 }
 
-module "acs" {
-  source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.4"
-  env    = "dev"
-}
-
 locals {
-  // needed to create the target_groups_map
-  target_group_suffixes = [
-    for tg in var.target_groups :
-    tg.name_suffix
-  ]
-  // needed to create the listeners_map
-  mappings = flatten([
-    for tg in var.target_groups :
-    [
-      for public_port in tg.listener_ports :
-      {
-        public_port         = public_port
-        target_group_suffix = tg.name_suffix
-      }
-    ]
-  ])
-  // needed to create the listeners_map
-  public_ports = [
-    for p in local.mappings :
-    tostring(p.public_port)
-  ]
-  // needed to create the listeners_map
-  listener_tg_suffixes = [
-    for p in local.mappings :
-    p.target_group_suffix
-  ]
-
-  // Used to create the map of target group resources
-  target_groups_map = zipmap(local.target_group_suffixes, var.target_groups)
-  // Used to create the map of listeners
-  listeners_map = zipmap(local.public_ports, local.listener_tg_suffixes)
+  public_ports = keys(var.listeners)
+  regular_listener_ports = toset(compact([
+    for port in local.public_ports :
+    (var.listeners[port].forward_to != null ? (! var.listeners[port].forward_to.ignore_changes ? port : null) : null)
+  ]))
+  ignore_forward_targets_listener_ports = toset(compact([
+    for port in local.public_ports :
+    (var.listeners[port].forward_to != null ? (var.listeners[port].forward_to.ignore_changes ? port : null) : null)
+  ]))
+  redirected_listener_ports = toset(compact([
+    for port in local.public_ports :
+    (var.listeners[port].redirect_to != null ? port : null)
+  ]))
 }
 
 resource "aws_alb" "alb" {
@@ -59,11 +36,11 @@ resource "aws_security_group" "alb-sg" {
 
   // allow access to the ALB from anywhere for each and every listener port defined in the target_groups variable
   dynamic "ingress" {
-    for_each = local.public_ports
+    for_each = var.listeners
     content {
       protocol  = "tcp"
-      from_port = ingress.value
-      to_port   = ingress.value
+      from_port = ingress.key
+      to_port   = ingress.key
       cidr_blocks = [
       "0.0.0.0/0"]
     }
@@ -83,27 +60,26 @@ resource "aws_security_group" "alb-sg" {
 
 // Map of target groups keyed by the name_suffix
 resource "aws_alb_target_group" "groups" {
-  for_each = local.target_groups_map
+  for_each = var.target_groups
 
-  name     = "${var.name}-tg-${each.value.name_suffix}"
+  name     = "${var.name}-tg-${each.key}"
   port     = each.value.port
   protocol = "HTTP"
   vpc_id   = var.vpc_id
 
-  // if the specific target group `config` is defined, use the specific config values. If not then use the `default_target_group_config` values.
-  target_type          = each.value.config != null ? each.value.config.type : var.default_target_group_config.type
-  deregistration_delay = each.value.config != null ? each.value.config.deregistration_delay : var.default_target_group_config.deregistration_delay
+  target_type          = each.value.type
+  deregistration_delay = each.value.deregistration_delay
   health_check {
-    path                = each.value.config != null ? each.value.config.health_check.path : var.default_target_group_config.health_check.path
-    interval            = each.value.config != null ? each.value.config.health_check.interval : var.default_target_group_config.health_check.interval
-    timeout             = each.value.config != null ? each.value.config.health_check.timeout : var.default_target_group_config.health_check.timeout
-    healthy_threshold   = each.value.config != null ? each.value.config.health_check.healthy_threshold : var.default_target_group_config.health_check.healthy_threshold
-    unhealthy_threshold = each.value.config != null ? each.value.config.health_check.unhealthy_threshold : var.default_target_group_config.health_check.unhealthy_threshold
+    path                = each.value.health_check.path
+    interval            = each.value.health_check.interval
+    timeout             = each.value.health_check.timeout
+    healthy_threshold   = each.value.health_check.healthy_threshold
+    unhealthy_threshold = each.value.health_check.unhealthy_threshold
   }
   stickiness {
     type            = "lb_cookie"
-    cookie_duration = each.value.config != null ? each.value.config.stickiness_cookie_duration : var.default_target_group_config.stickiness_cookie_duration
-    enabled         = each.value.config != null ? each.value.config.stickiness_cookie_duration != null : var.default_target_group_config.stickiness_cookie_duration != null
+    cookie_duration = each.value.stickiness_cookie_duration
+    enabled         = each.value.stickiness_cookie_duration != null
   }
 
   tags = var.tags
@@ -112,40 +88,62 @@ resource "aws_alb_target_group" "groups" {
 }
 
 // Map of listeners keyed by the listener port
-resource "aws_alb_listener" "listeners" {
-  for_each = var.is_blue_green ? {} : local.listeners_map
+resource "aws_alb_listener" "regular_listeners" {
+  for_each = local.regular_listener_ports
 
   load_balancer_arn = aws_alb.alb.arn
   port              = tonumber(each.key)
 
-  protocol        = tonumber(each.key) == 443 ? "HTTPS" : "HTTP"
-  certificate_arn = tonumber(each.key) == 443 ? module.acs.certificate.arn : null
+  protocol        = var.listeners[each.key].protocol
+  certificate_arn = var.listeners[each.key].https_certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_alb_target_group.groups[each.value].arn
+    target_group_arn = aws_alb_target_group.groups[var.listeners[each.key].forward_to.target_group].arn
   }
 
   depends_on = [aws_alb.alb, aws_alb_target_group.groups]
 }
-
-// Map of listeners keyed by the listener port
-resource "aws_alb_listener" "blue_green_listeners" {
-  for_each = var.is_blue_green ? local.listeners_map : {}
+resource "aws_alb_listener" "ignore_forward_target_listeners" {
+  for_each = local.ignore_forward_targets_listener_ports
 
   load_balancer_arn = aws_alb.alb.arn
   port              = tonumber(each.key)
 
-  protocol        = tonumber(each.key) == 443 ? "HTTPS" : "HTTP"
-  certificate_arn = tonumber(each.key) == 443 ? module.acs.certificate.arn : null
+  protocol        = var.listeners[each.key].protocol
+  certificate_arn = var.listeners[each.key].https_certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_alb_target_group.groups[each.value].arn
+    target_group_arn = aws_alb_target_group.groups[var.listeners[each.key].forward_to.target_group].arn
   }
 
   lifecycle {
     ignore_changes = [default_action[0].target_group_arn]
   }
+  depends_on = [aws_alb.alb, aws_alb_target_group.groups]
+}
+
+// Map of listeners keyed by the listener port
+resource "aws_alb_listener" "redirected_listeners" {
+  for_each = local.redirected_listener_ports
+
+  load_balancer_arn = aws_alb.alb.arn
+  port              = tonumber(each.key)
+
+  protocol        = var.listeners[each.key].protocol
+  certificate_arn = var.listeners[each.key].https_certificate_arn
+
+  default_action {
+    type = "redirect"
+    redirect {
+      host        = var.listeners[each.key].redirect_to.host
+      path        = var.listeners[each.key].redirect_to.path
+      port        = var.listeners[each.key].redirect_to.port
+      protocol    = var.listeners[each.key].redirect_to.protocol
+      status_code = "HTTP_301"
+    }
+  }
+
   depends_on = [aws_alb.alb, aws_alb_target_group.groups]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,10 @@
+terraform {
+  required_version = ">= 0.12.16"
+  required_providers {
+    aws = ">= 2.42"
+  }
+}
+
 module "acs" {
   source = "git@github.com:byu-oit/terraform-aws-acs-info.git?ref=v1.0.4"
   env    = "dev"

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "target_groups" {
 }
 
 output "listeners" {
-  value = var.is_blue_green ? aws_alb_listener.blue_green_listeners : aws_alb_listener.listeners
+  value = merge(aws_alb_listener.regular_listeners, aws_alb_listener.ignore_forward_target_listeners, aws_alb_listener.redirected_listeners)
 }
 
 output "alb_security_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,12 +11,16 @@ variable "subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs for the targets of the ALB."
 }
-variable "default_target_group_config" {
-  type = object({
-    type                       = string // instance
-    deregistration_delay       = number // 300
-    slow_start                 = number // 0
-    stickiness_cookie_duration = number // null
+
+variable "target_groups" {
+  type = map(object({
+    port                 = number
+    type                 = string
+    deregistration_delay = number
+    // 300
+    slow_start = number
+    // 0
+    stickiness_cookie_duration = number
     health_check = object({
       path                = string
       interval            = number
@@ -24,37 +28,28 @@ variable "default_target_group_config" {
       healthy_threshold   = number
       unhealthy_threshold = number
     })
-  })
-  description = "Default configuration for `target_groups`"
+  }))
+  description = "Map of target groups with the key as the target group name suffix"
 }
-variable "target_groups" {
-  type = list(object({
-    name_suffix    = string
-    listener_ports = list(number)
-    port           = number
-    config = object({
-      type                 = string
-      deregistration_delay = number // 300
-      slow_start           = number // 0
-      health_check = object({
-        path                = string
-        interval            = number
-        timeout             = number
-        healthy_threshold   = number
-        unhealthy_threshold = number
-      })
-      stickiness_cookie_duration = number
+variable "listeners" {
+  type = map(object({
+    protocol              = string
+    https_certificate_arn = string
+    forward_to = object({
+      target_group   = string
+      ignore_changes = bool
+    })
+    redirect_to = object({
+      host     = string
+      path     = string
+      port     = number
+      protocol = string
     })
   }))
-  description = "List of information defining the target groups to create"
+  description = "Map of listeners with the key as the public port of the listener"
 }
 
 // Optional
-variable "is_blue_green" {
-  type = bool
-  description = "Boolean to identify that this ALB will be used for blue green deployments. `true` will cause the listeners to ignore changes to the forwarded target group because code deploy can change that."
-  default = false
-}
 variable "idle_timeout" {
   type        = number
   description = "The time in seconds that the connection is allowed to be idle. Defaults to 60."

--- a/variables.tf
+++ b/variables.tf
@@ -11,15 +11,12 @@ variable "subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs for the targets of the ALB."
 }
-
 variable "target_groups" {
   type = map(object({
     port                 = number
     type                 = string
     deregistration_delay = number
-    // 300
     slow_start = number
-    // 0
     stickiness_cookie_duration = number
     health_check = object({
       path                = string


### PR DESCRIPTION
Removed acs-info module and changed how listeners and target_groups variables work. Changing teh contract so we'll go to v1.2.0.

This PR fixes #2 and allows you to redirect traffic from one listener to another.